### PR TITLE
Update parsing for Puppet 7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class pxe (
   class { 'pxe::syslinux':
     tftp_root        => $tftp_root,
     syslinux_version => $syslinux_version,
+    syslinux_major_version => $syslinux_major_version,
   }
   if $tools {
     include pxe::tools

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@
 class pxe (
   $tftp_root        = '/srv/tftp',
   $syslinux_version = $pxe::params::syslinux_version,
+  $syslinux_major_version = $pxe::params::syslinux_version,
   $tools            = true,
 ) inherits pxe::params {
   class { 'pxe::syslinux':

--- a/manifests/syslinux.pp
+++ b/manifests/syslinux.pp
@@ -12,7 +12,7 @@ class pxe::syslinux (
       tftp_root    => $tftp_root,
     }
   } elsif $syslinux_version =~ /^([0-9]+)\./ {
-    $syslinux_major_version = $1
+    $syslinux_major_version = split($syslinux_version, '.')[0]
     class { 'pxe::syslinux::direct':
       syslinux_dir     => "/usr/local/src/syslinux-${syslinux_version}",
       syslinux_archive => "https://www.kernel.org/pub/linux/utils/boot/syslinux/${syslinux_major_version}.xx/syslinux-${syslinux_version}.tar.gz",

--- a/manifests/syslinux.pp
+++ b/manifests/syslinux.pp
@@ -13,7 +13,7 @@ class pxe::syslinux (
     }
   } elsif $syslinux_version =~ /^([0-9]+)\./ {
     $syslinux_version_parsed = split($syslinux_version, '.')
-    $syslinux_major_version = $syslinux_version_parsed[0]
+    $syslinux_major_version = $syslinux_version_parsed[1]
 
     class { 'pxe::syslinux::direct':
       syslinux_dir     => "/usr/local/src/syslinux-${syslinux_version}",

--- a/manifests/syslinux.pp
+++ b/manifests/syslinux.pp
@@ -3,6 +3,7 @@
 #
 class pxe::syslinux (
   String[1] $syslinux_version,
+  String[1] $syslinux_major_version,
   String[1] $tftp_root,
   String[1] $system_syslinux_dir   = $pxe::params::system_syslinux_dir,
 ) inherits pxe::params {
@@ -12,8 +13,6 @@ class pxe::syslinux (
       tftp_root    => $tftp_root,
     }
   } elsif $syslinux_version =~ /^([0-9]+)\./ {
-    $syslinux_version_parsed = split($syslinux_version, '.')
-    $syslinux_major_version = $syslinux_version_parsed[1]
 
     class { 'pxe::syslinux::direct':
       syslinux_dir     => "/usr/local/src/syslinux-${syslinux_version}",

--- a/manifests/syslinux.pp
+++ b/manifests/syslinux.pp
@@ -12,7 +12,9 @@ class pxe::syslinux (
       tftp_root    => $tftp_root,
     }
   } elsif $syslinux_version =~ /^([0-9]+)\./ {
-    $syslinux_major_version = split($syslinux_version, '.')[0]
+    $syslinux_version_parsed = split($syslinux_version, '.')
+    $syslinux_major_version = $syslinux_version_parsed[0]
+
     class { 'pxe::syslinux::direct':
       syslinux_dir     => "/usr/local/src/syslinux-${syslinux_version}",
       syslinux_version => $syslinux_version,

--- a/manifests/syslinux.pp
+++ b/manifests/syslinux.pp
@@ -15,6 +15,7 @@ class pxe::syslinux (
     $syslinux_major_version = split($syslinux_version, '.')[0]
     class { 'pxe::syslinux::direct':
       syslinux_dir     => "/usr/local/src/syslinux-${syslinux_version}",
+      syslinux_version => $syslinux_version,
       syslinux_archive => "https://www.kernel.org/pub/linux/utils/boot/syslinux/${syslinux_major_version}.xx/syslinux-${syslinux_version}.tar.gz",
       tftp_root        => $tftp_root,
     }

--- a/manifests/syslinux/direct.pp
+++ b/manifests/syslinux/direct.pp
@@ -2,6 +2,7 @@ class pxe::syslinux::direct (
   String[1] $tftp_root,
   String[1] $syslinux_archive,
   String[1] $syslinux_dir,
+  String[1] $syslinux_version,
 ) {
   if $syslinux_dir =~ /syslinux-([0-9.]+)$/ {
     $syslinux_version = $1

--- a/manifests/syslinux/direct.pp
+++ b/manifests/syslinux/direct.pp
@@ -4,9 +4,6 @@ class pxe::syslinux::direct (
   String[1] $syslinux_dir,
   String[1] $syslinux_version,
 ) {
-  if $syslinux_dir =~ /syslinux-([0-9.]+)$/ {
-    $syslinux_version = $1
-  }
   file { $syslinux_dir:
     ensure => directory;
   }

--- a/manifests/tools/memtest.pp
+++ b/manifests/tools/memtest.pp
@@ -3,21 +3,21 @@
 # Adds the memtest image to the menu
 #
 class pxe::tools::memtest (
-  $url = 'http://www.memtest.org/download/4.20/memtest86+-4.20.bin.gz',
+  $url = 'https://www.memtest.org/download/v6.20/mt86plus_6.20.binaries.zip',
   $tftp_root = $pxe::tftp_root
 ) {
-  archive { "${tftp_root}/tools/memtest86+-4.20.bin.gz":
+  archive { "${tftp_root}/tools/mt86plus_6.20.binaries.zip":
     ensure       => present,
     source       => $url,
     extract      => true,
     extract_path => "${tftp_root}/tools",
-    creates      => "${tftp_root}/tools/memtest86+-4.20.bin",
+    creates      => "${tftp_root}/tools/memtest32.bin",
     require      => Class['Pxe::Tools'];
   }
   file { "${tftp_root}/tools/memtest86+":
     ensure  => link,
-    target  => "${tftp_root}/tools/memtest86+-4.20.bin",
-    require => Archive["${tftp_root}/tools/memtest86+-4.20.bin.gz"];
+    target  => "${tftp_root}/tools/memtest32.bin",
+    require => Archive["${tftp_root}/tools/mt86plus_6.20.binaries.zip"];
   }
 
   # Create the menu entry


### PR DESCRIPTION
Prior to this commit , puppet 7 would not use the back ref to the match groups

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
